### PR TITLE
[Upgrade] Vale to 2.2.2

### DIFF
--- a/packages/Vale/tools/chocolateyinstall.ps1
+++ b/packages/Vale/tools/chocolateyinstall.ps1
@@ -1,33 +1,21 @@
 $ErrorActionPreference = 'Stop';
 
-# Insert here full correct name of program, not Chocolatey package name. For example, correct «Performance Maintainer», not «pername».
 $packageName = 'Vale'
-# Don't forget specify protocol for URL's!
-$url         = 'https://github.com/errata-ai/vale/releases/download/v1.0.3/vale.msi'
-$url64       = ''
+$toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url         = ''
+$url64       = 'https://github.com/errata-ai/vale/releases/download/v2.2.2/vale_2.2.2_Windows_64-bit.zip'
 
 $packageArgs = @{
   packageName   = $packageName
-
-  fileType      = 'msi'
+  unzipLocation = $toolsDir
   url           = $url
   url64bit      = $url64
 
-  # If exit code — 1223, program will be still installed with success.
-  validExitCodes = (0, 1223)
+  checksum        = ''
+  checksumType    = ''
+  checksum64      = '63ed5385da45f3fc1001e0295a4fe0d84d3cea192fc03ed92aa06120e8132af6'
+  checksumType64  = 'sha256'
 
-  checksum      = 'AF2E90EADE1DC3DC61E9F7B6DA5950BD5A51F548F52A15B12DC19F4384D0C8E5'
-  checksumType  = 'sha256'
-  checksum64    = ''
-  checksumType64= ''
-
-  ######
-  # MSI
-  ######
-  # Remove msiexec.exe, filename and /i argument from USSF for silentArgs value. For example, if USSF show «msiexec.exe /i "PowerResizerSetup.msi" /qb», insert in SilentArgs «/qb».
-  ######
-
-  silentArgs   = '/qb'
 }
 
-Install-ChocolateyPackage @packageArgs
+Install-ChocolateyZipPackage @packageArgs

--- a/packages/Vale/vale.nuspec
+++ b/packages/Vale/vale.nuspec
@@ -4,7 +4,7 @@
 	<metadata>
 		<!-- id — lowercase name of package, title — real name of program -->
 		<id>vale</id>
-		<version>1.0.3</version>
+		<version>2.2.2</version>
 		<title>Vale</title>
 		<authors>Joseph Kato</authors>
 		<owners>Sasha Chernykh</owners>
@@ -13,7 +13,7 @@
 		<!-- It would be nice, if you don't use whitespaces in path to image. -->
 		<iconUrl>https://cdn.rawgit.com/Kristinita/SashaChocolatey/master/icons/Vale.png</iconUrl>
 		<packageSourceUrl>https://github.com/Kristinita/SashaChocolatey/tree/master/packages/Vale</packageSourceUrl>
-		<docsUrl>https://errata.ai/vale/getting-started/</docsUrl>
+		<docsUrl>https://github.com/errata-ai/vale</docsUrl>
 		<!-- Points to the forum or email list group for the software. -->
 		<mailingListUrl>mailto:joesph@jdkato.io</mailingListUrl>
 		<bugTrackerUrl>https://github.com/errata-ai/vale/issues</bugTrackerUrl>
@@ -22,7 +22,7 @@
 		<summary>Vale — the customizable linter for prose.</summary>
 		<description>Vale is a free, open-source linter for prose built with speed and extensibility in mind.</description>
 		<releaseNotes>Like the other extension points, this will intelligently ignore certain syntax constructs (e.g., code blocks, URLs, etc.)</releaseNotes>
-		<copyright>© 2018</copyright>
+		<copyright>© 2020</copyright>
 		<!-- Write tags through spaces -->
 		<!-- Add «admin» (without «qoutes») tag, if your package are .exe or .msi -->
 		<tags>vale linter prose admin</tags>


### PR DESCRIPTION
Hey @jdkato and @Kristinita I was attempting to update Vale to version 2.1.1 and got very stuck with creating the MSI part, which is probably where Joseph got stuck in the first place and started dropping support for chocolatey. But I wanted to attempt to keep it going.

I was testing locally first and though I was able to generate an exe easily, but using `go-msi` on my Windows VM doesn't seem to work with errors like

`Rel: can't make \vale\vale.exe relative to C:\Users\CHRIS\AppData\Local\Temp\go-msi189551703`

in the long run of course we'd want to move this to a build service, but I wanted to understand the process. Any pointers? I see it's also possible to create choco packages with an exe instead, maybe that's easier?