### PR TITLE
feat(update): Vale to 2.9.1

### DIFF
--- a/packages/Vale/tools/chocolateyinstall.ps1
+++ b/packages/Vale/tools/chocolateyinstall.ps1
@@ -2,14 +2,14 @@ $ErrorActionPreference = 'Stop';
 
 $packageName = 'Vale'
 $toolsDir    = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url64       = 'https://github.com/errata-ai/vale/releases/download/v2.9.0/vale_2.9.0_Windows_64-bit.zip'
+$url64       = 'https://github.com/errata-ai/vale/releases/download/v2.9.1/vale_2.9.1_Windows_64-bit.zip'
 
 $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
   url64bit      = $url64
 
-  checksum64      = '2a7965a4ef71ccbc5b219b42ae582e6f64359557b68baf890dbebea63be5c318'
+  checksum64      = '971090d08fd52788ea132efdedb9e238005db81c9cb74d5c339ba07e02a9d6b2'
   checksumType64  = 'sha256'
 
 }

--- a/packages/Vale/vale.nuspec
+++ b/packages/Vale/vale.nuspec
@@ -4,7 +4,7 @@
 	<metadata>
 		<!-- id — lowercase name of package, title — real name of program -->
 		<id>vale</id>
-		<version>2.9.0</version>
+		<version>2.9.1</version>
 		<title>Vale</title>
 		<authors>Joseph Kato</authors>
 		<owners>Sasha Chernykh</owners>
@@ -22,7 +22,7 @@
 		<summary>Vale — the customizable linter for prose.</summary>
 		<description>Vale is a free, open-source linter for prose built with speed and extensibility in mind.</description>
 		<releaseNotes>Like the other extension points, this will intelligently ignore certain syntax constructs (e.g., code blocks, URLs, etc.)</releaseNotes>
-		<copyright>© 2020</copyright>
+		<copyright>© 2021</copyright>
 		<!-- Write tags through spaces -->
 		<!-- Add «admin» (without «qoutes») tag, if your package are .exe or .msi -->
 		<tags>vale linter prose admin</tags>


### PR DESCRIPTION
There was actually a path error in the last PR @jdkato I only noticed it after the chocolatey automatic testing failed.